### PR TITLE
[LB-75] 로컬용 argocd, argo-apps helm 배포 테라폼 코드 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 .idea
+
+*.tfstate
+*.tfstate.*
+.terraform/
+crash.log
+*.log
+*.tfvars
+override.tf
+override.tf.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "values"]
+	path = values
+	url = https://github.com/LGCNS-FINAL-LGCMS/infra-helm-values.git

--- a/local/.terraform.lock.hcl
+++ b/local/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "3.0.2"
+  hashes = [
+    "h1:tOye2RnjFNXH236AsqGaIWtz4j6PZrpPuJhOSBt0KxU=",
+    "zh:2778de76c7dfb2e85c75fe6de3c11172a25551ed499bfb9e9f940a5be81167b0",
+    "zh:3b4c436a41e4fbae5f152852a9bd5c97db4460af384e26977477a40adf036690",
+    "zh:617a372f5bb2288f3faf5fd4c878a68bf08541cf418a3dbb8a19bc41ad4a0bf2",
+    "zh:84de431479548c96cb61c495278e320f361e80ab4f8835a5425ece24a9b6d310",
+    "zh:8b4cf5f81d10214e5e1857d96cff60a382a22b9caded7f5d7a92e5537fc166c1",
+    "zh:baeb26a00ffbcf3d507cdd940b2a2887eee723af5d3319a53eec69048d5e341e",
+    "zh:ca05a8814e9bf5fbffcd642df3a8d9fae9549776c7057ceae6d6f56471bae80f",
+    "zh:ca4bf3f94dedb5c5b1a73568f2dad7daf0ef3f85e688bc8bc2d0e915ec148366",
+    "zh:d331f2129fd3165c4bda875c84a65555b22eb007801522b9e017d065ac69b67e",
+    "zh:e583b2b478dde67da28e605ab4ef6521c2e390299b471d7d8ef05a0b608dcdad",
+    "zh:f238b86611647c108c073d265f8891a2738d3158c247468ae0ff5b1a3ac4122a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.37.1"
+  constraints = "~> 2.25"
+  hashes = [
+    "h1:+37jC6JlkPyPvDHudK3qaj7ZVJ0Zy9zc9+oq8h1WayA=",
+    "zh:0ed097413c7fc804479e325966886b405dc0b75ad2b4f54ce4df1d8e4802b397",
+    "zh:17dcf4a685a00d2d048671124e8a1a8e836b58ecd2ef628a1c666fe0ced2e598",
+    "zh:36891284e5bced57c438f12d0b27856b0d4b70b562bd200b01919a6a89545be9",
+    "zh:3e49d86b508e641ba122d1b0af24cdc4d8ffa2ec1b30022436fb1d7c6ba696ea",
+    "zh:40be623e116708bdcb0fac32989db43720f031c5fe9a4dc63395078185d24403",
+    "zh:44fc0ac3bc39e289b67f9dde7ee9fef29eb8192197e5e68fee69098573021722",
+    "zh:957aa451573bcde5d57f6f8338ea3139010c7f61fefe8f6a140a8c267f056511",
+    "zh:c55fd85b7e8acaac17e30670ac3574b88b3530820dd004bcd2a5daa8624a46e9",
+    "zh:c743f06843a1f5ecde2b8ef639f4d3db654a334ef248dee57261c719ea843f3a",
+    "zh:c93cc71c64b838d89522ac5fb60f68e0e1e7f2fc39db6b0ead7afd78795e79ed",
+    "zh:eda1163c2266905adc54bc78cc3e7b606a164fbc6b59be607db933b302015ccd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/local/argo.tf
+++ b/local/argo.tf
@@ -1,0 +1,49 @@
+# resource "kubernetes_namespace" "argo_ns" {
+#   metadata {
+#     annotations = {
+#       name = "argocd"
+#     }
+#
+#     name = "argocd"
+#   }
+# }
+
+resource "helm_release" "argo-cd" {
+  name = "argo-cd"
+  repository = "https://argoproj.github.io/argo-helm"
+  chart = "argo-cd"
+  version = "8.1.3"
+  namespace = "default"
+
+  values = [
+    file("../values/local/argocd/argocd_values.yaml")
+  ]
+
+#   depends_on = [
+#     kubernetes_namespace.argo_ns
+#   ]
+}
+
+resource "kubernetes_manifest" "argocd-github-access" {
+  manifest = yamldecode(file("../values/local/argocd/argocd_github_secret.yaml"))
+#   depends_on = [
+#     kubernetes_namespace.argo_ns
+#   ]
+}
+
+resource "helm_release" "argocd-apps" {
+  name = "argocd-apps"
+  repository = "https://argoproj.github.io/argo-helm"
+  chart = "argocd-apps"
+  version = "2.0.2"
+  namespace = "default"
+
+  values = [
+    file("../values/local/argocd/argocd_apps_values.yaml")
+  ]
+
+  depends_on = [
+    helm_release.argo-cd,
+    kubernetes_manifest.argocd-github-access
+  ]
+}

--- a/local/main.tf
+++ b/local/main.tf
@@ -1,0 +1,10 @@
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+  config_context = "docker-desktop"
+}
+
+provider "helm" {
+  kubernetes = {
+    config_path = "~/.kube/config"
+  }
+}


### PR DESCRIPTION
## 작업 내용
    - 테라폼 기반 helm 배포
      - argo-cd 헬름 패키지를 이용해 argocd를 배포합니다.
      - argocd-apps 헬름 패키지를 이용해 argocd 로 배포할 애플리케이션을 배포합니다.
    - 프라이빗 레포지토리 접근을 위한 secret 리소스
## 회고, 느낀점
    - argocd와 애플리케이션 간의 네임스페이스 분리를 실패해서 추후 다른 서비스 작업을 진행하며 테스트 해보며 전환하겠습니다.